### PR TITLE
Ensure that semicolons in query and fragment strings are url-encoded.

### DIFF
--- a/src/main/java/org/dataone/service/util/EncodingUtilities.java
+++ b/src/main/java/org/dataone/service/util/EncodingUtilities.java
@@ -152,7 +152,6 @@ public class EncodingUtilities {
 		fragmentUnescapedCharacters = (BitSet) pcharUnescapedCharacters.clone();
 		fragmentUnescapedCharacters.set('/');
 		fragmentUnescapedCharacters.set('?');
-		fragmentUnescapedCharacters.set(';');
 
 		// set up queryUnescapedCharacters - in ABNF, is the same as frag
 		// but have to remove a couple character to follow key-value pair convention

--- a/src/test/resources/org/dataone/service/encodingTestSet/testUnicodeStrings.utf8.txt
+++ b/src/test/resources/org/dataone/service/encodingTestSet/testUnicodeStrings.utf8.txt
@@ -29,10 +29,10 @@ path-unicode-ascii-escaped-double-//case	path-unicode-ascii-escaped-double-%2F%2
 path-unicode-ascii-escaped-double-trailing//	path-unicode-ascii-escaped-double-trailing%2F%2F
 path-unicode-ascii-escaped-double-%2F%2Fcase	path-unicode-ascii-escaped-double-%252F%252Fcase
 path-unicode-ascii-escaped-double-trailing%2F%2F	path-unicode-ascii-escaped-double-trailing%252F%252F
-query-unicode-ascii-safe-;	query-unicode-ascii-safe-;
+query-unicode-ascii-safe-;	query-unicode-ascii-safe-%3B
 query-unicode-ascii-safe-/?	query-unicode-ascii-safe-/?
 query-unicode-ascii-escaped-&=&=	query-unicode-ascii-escaped-%26%3D%26%3D
-fragment-unicode-ascii-safe-;	fragment-unicode-ascii-safe-;
+fragment-unicode-ascii-safe-;	fragment-unicode-ascii-safe-%3B
 fragment-unicode-ascii-safe-&=&=/?	fragment-unicode-ascii-safe-&=&=/?
 common-unicode-bmp-1byte-escaped-¡¢£	common-unicode-bmp-1byte-escaped-%C2%A1%C2%A2%C2%A3
 common-unicode-bmp-2byte-escaped-䦹䦺	common-unicode-bmp-2byte-escaped-%E4%A6%B9%E4%A6%BA


### PR DESCRIPTION
Changed code so that semicolons `;` are no longer in the reserved set and will be url-encoded in the query string and fragment string portions of a URL. Adjusted the tests to match.

Closes issue #8 